### PR TITLE
Board implementation using bitboards and bitwise manipulation

### DIFF
--- a/src/board.py
+++ b/src/board.py
@@ -9,8 +9,25 @@ class Board:
     def __str__(self):
         board_string = ""
 
-        for symbol in self.board.keys():
-            board_string += symbol + ": " + bin(self.board[symbol])[2:].zfill(9) + "\n"
+        # Four "+" signs each separated by a 3-length "-" sequence.
+        horizontal_border = ("-" * 3).join(["+"] * 4)
+
+        grid_board = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+
+        for i in range(3):
+            for j in range(3):
+                for symbol in "XO":
+                    if self.board[symbol] & (1 << (8 - (3 * i + j))):
+                        grid_board[i][j] = symbol
+
+        for i in range(3):
+            board_string += horizontal_border + "\n"
+
+            cell_separator = " | "
+            row = [str(elem) if elem != 0 else str(3 * i + index + 1) for (index, elem) in enumerate(grid_board[i])]
+            board_string += f"| {cell_separator.join(row)} |" + "\n"
+
+        board_string += horizontal_border + "\n"
 
         return board_string
 


### PR DESCRIPTION
This pull request replaces the list-based implementation of the board with a bitboard. The bitboard is a `dict`:
```python
bitboard = {
    "X": 0,
    "O": 0
}
```
This implementation has the potential to be faster. It also allows for easier and more concise generation of bit masks if the project is expanded to support varying `N x N` sizes of board. Using less strings and only using two integers to represent the whole board is also a potential speed and space optimization.